### PR TITLE
Allow multi in moveAllLocation

### DIFF
--- a/modules/php/Helpers/Pieces.php
+++ b/modules/php/Helpers/Pieces.php
@@ -383,7 +383,7 @@ class Pieces extends DB_Manager
   public static function moveAllInLocation($fromLocation, $toLocation, $fromState = null, $toState = 0)
   {
     if (!is_null($fromLocation)) {
-      self::checkLocation($fromLocation);
+      self::checkLocation($fromLocation, true);
     }
     self::checkLocation($toLocation);
 
@@ -397,7 +397,7 @@ class Pieces extends DB_Manager
    */
   public static function moveAllInLocationKeepState($fromLocation, $toLocation)
   {
-    self::checkLocation($fromLocation);
+    self::checkLocation($fromLocation, true);
     self::checkLocation($toLocation);
     return self::moveAllInLocation($fromLocation, $toLocation, null, null);
   }


### PR DESCRIPTION
I am using this modification in one of my games, and it might be worth putting in the base version.

This is to allow moving all pieces from a wildcard location to a single specified location.